### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/neo4j-graph.js
+++ b/lib/neo4j-graph.js
@@ -2,7 +2,7 @@ var neo4j = require("neo4j");
 var util = require("util");
 var Connector = require("loopback-connector").Connector;
 var debug = require("debug")("loopback:connector:neo4j-graph");
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 var Promise = require("bluebird");
 
 /**

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "debug": "^2.2.0",
     "loopback-connector": "^2.3.0",
     "neo4j": "^2.0.0-RC2",
-    "node-uuid": "^1.4.7",
-    "util": "^0.10.3"
+    "util": "^0.10.3",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "^2.4.5",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.